### PR TITLE
Adding 2023 timing scans

### DIFF
--- a/Phase1ScanHistoMaker.cc
+++ b/Phase1ScanHistoMaker.cc
@@ -204,7 +204,9 @@ int main(int argc, char* argv[]) {
 		       (e.bx==291||e.bx==1185||e.bx==2079) ? 2 :
 		       (size_t)-1; }, "BXm1;BX0;BXp1", "First BX -1;First BX;First BX +1", "601,418,633");
   
-  sh.AddNewPostfix("DelayScans",        [&v]{ if (v.pf_delay_scan==-1) return (size_t)-1; return (size_t)v.pf_delay_scan-46;   }, "2022SepMiniScan", "", "1");
+  sh.AddNewPostfix("DelayScans",        [&v]{ if (v.pf_delay_scan==-1) return (size_t)-1; return (size_t)v.pf_delay_scan-48;   }, "2023Apr_FullScan", "", "1");
+  //sh.AddNewPostfix("DelayScans",        [&v]{ if (v.pf_delay_scan==-1) return (size_t)-1; return (size_t)v.pf_delay_scan-47;   }, "2023Apr_MiniScan", "", "1");
+  //sh.AddNewPostfix("DelayScans",        [&v]{ if (v.pf_delay_scan==-1) return (size_t)-1; return (size_t)v.pf_delay_scan-46;   }, "2022Sep_MiniScan", "", "1");
   //sh.AddNewPostfix("DelayScans",        [&v]{ if (v.pf_delay_scan==-1) return (size_t)-1; return (size_t)v.pf_delay_scan-45;   }, "2022Jul_FullScan", "", "1");
   //sh.AddNewPostfix("DelayScans",        [&v]{ if (v.pf_delay_scan==-1) return (size_t)-1; return (size_t)v.pf_delay_scan-44;   }, "2022Jun_MiniScan", "", "1");
   //sh.AddNewPostfix("DelayScans",        [&v]{ if (v.pf_delay_scan==-1) return (size_t)-1; return (size_t)v.pf_delay_scan-43;   }, "2021Nov_MiniScan", "", "1");

--- a/interface/scan_points.h
+++ b/interface/scan_points.h
@@ -380,8 +380,6 @@ namespace scans {
     case 352908: return 44;
     case 352909: return 44;
 
-    case 352931: return 44;
-
       // 2022
       // Scan 2 - July 2022 full scan
       // http://cmsonline.cern.ch/cms-elog/1145828
@@ -408,6 +406,7 @@ namespace scans {
     case 355127: return 45;
     case 355128: return 45;
     case 355129: return 45;
+
       // 2022
       // Scan 3 - Sep 2022 mini scan
       // http://cmsonline.cern.ch/cms-elog/1157556
@@ -419,6 +418,40 @@ namespace scans {
     case 359581: return 46;
     case 359582: return 46;
     case 359584: return 46;
+
+      // 2023
+      // Scan 1 - Apr 2023 mini scan
+      // http://cmsonline.cern.ch/cms-elog/1177502
+    case 365835: return 47;
+    case 365836: return 47;
+    case 365837: return 47;
+    case 365838: return 47;
+    case 365839: return 47;
+    case 365840: return 47;
+    case 365841: return 47;
+    case 365842: return 47;
+
+      // 2023
+      // Scan 2 - Apr 2023 full scan
+      // hhttp://cmsonline.cern.ch/cms-elog/1179227
+    case 366406: return 48;
+    case 366409: return 48;
+    case 366410: return 48;
+    case 366413: return 48;
+    case 366419: return 48;
+    case 366422: return 48;
+    case 366424: return 48;
+    case 366426: return 48;
+    case 366427: return 48;
+    case 366429: return 48;
+    case 366432: return 48;
+    case 366436: return 48;
+    case 366437: return 48;
+    case 366438: return 48;
+    case 366439: return 48;
+    case 366440: return 48;
+    case 366441: return 48;
+    case 366442: return 48;
 
     default:
       return -1;
@@ -1195,6 +1228,40 @@ namespace scans {
     case 359581: return -2.;
     case 359582: return -1.;
     case 359584: return 0.;
+
+      // 2023
+      // Scan 1 - Apr 2022 mini scan
+      // http://cmsonline.cern.ch/cms-elog/1177502
+    case 365835: return -3.;
+    case 365836: return -2.;
+    case 365837: return -1.;
+    case 365838: return 1.;
+    case 365839: return 2.;
+    case 365840: return 3.;
+    case 365841: return 5.;
+    case 365842: return 0.;
+
+      // 2023
+      // Scan 2 - Apr 2023 full scan
+      // http://cmsonline.cern.ch/cms-elog/1179227
+    case 366406: return 1.;
+    case 366409: return 2.;
+    case 366410: return 3.;
+    case 366413: return 4.;
+    case 366419: return 5.;
+    case 366422: return 6.;
+    case 366424: return 7.;
+    case 366426: return 9.;
+    case 366427: return -1.;
+    case 366429: return -2.;
+    case 366432: return -3.;
+    case 366436: return -5.;
+    case 366437: return -7.;
+    case 366438: return -9.;
+    case 366439: return -11.;
+    case 366440: return -13.;
+    case 366441: return -15.;
+    case 366442: return 0.;
 
       /*
     case 2: 


### PR DESCRIPTION
This PR takes the 2023 scans from https://github.com/CMSTrackerDPG/SiPixelTools-PixelHistoMaker/pull/4 and adds then to the `main` branch. The 2022 timing scans are already on the `main` branch.